### PR TITLE
Fix NFT Drop Get Owned wrong snippet

### DIFF
--- a/docs/onboarding/4 Pre-Built Contracts/4 01 NFT Drop.mdx
+++ b/docs/onboarding/4 Pre-Built Contracts/4 01 NFT Drop.mdx
@@ -157,7 +157,7 @@ Our SDKs provide helpful ways to view the NFTs in your collection.
 
 ### NFTs owned by a specific wallet
 
-<ThirdwebCodeSnippet contract={"NFTDrop"} name={"balanceOf"} />
+<ThirdwebCodeSnippet contract={"NFTDrop"} name={"getOwned"} />
 
 ## Viewing Supply
 


### PR DESCRIPTION
https://portal.thirdweb.com/pre-built-contracts/edition-drop#nfts-owned-by-a-specific-wallet

This is using the wrong snippet