### PR TITLE
Add Devbook examples to Signature Drop page

### DIFF
--- a/docs/snippets.json
+++ b/docs/snippets.json
@@ -2437,6 +2437,9 @@
     "name": "ContractDeployer",
     "summary": "Handles deploying new contracts\n\n\n",
     "examples": {},
+    "codeSnippet": {
+      "javascript": "2quu7XPcHpmB"
+    },
     "methods": [
       {
         "name": "deployEdition",
@@ -2558,6 +2561,9 @@
         }
       },
       {
+        "codeSnippet": {
+          "javascript": "VUSQyKVLudnM"
+        },
         "name": "deploySignatureDrop",
         "summary": "Deploys a new SignatureDrop contract\n\n",
         "remarks": "\n\nDeploys a SignatureDrop contract and returns the address of the deployed contract\n\n",
@@ -3119,10 +3125,13 @@
   },
   "SignatureDrop": {
     "name": "SignatureDrop",
-    "summary": "Setup a collection of NFTs where when it comes to minting, you can authorize some external party to mint tokens on your contract, and specify what exactly will be minted by that external party..\n\n",
+    "summary": "Setup a collection of NFTs wheref when it comes to minting, you can authorize some external party to mint tokens on your contract, and specify what exactly will be minted by that external party..\n\n",
     "examples": {
-      "javascript": "import { ThirdwebSDK } from \"@thirdweb-dev/sdk\";\n\nconst sdk = new ThirdwebSDK(\"{{chainName}}\");\nconst contract = sdk.getSignatureDrop(\"{{contract_address}}\");",
+      "javascript": "import { ThirdwebSDK } from \"@thirdweb-dev/sdk\";\n\nconst sdk = new ThirdwebSDK(process.env.chain_name);\nconst contract = sdk.getSignatureDrop(process.env.contract_address);",
       "react": "import { useSignatureDrop } from '@thirdweb-dev/react'\n\nexport default function Component() {\n  const signatureDrop = useSignatureDrop(\"<YOUR-CONTRACT-ADDRESS>\")\n\n  // Now you can use the Signature drop contract in the rest of the component\n}"
+    },
+    "codeSnippet": {
+      "javascript": "iuj78ZjwlEcv"
     },
     "methods": [
       {
@@ -3160,6 +3169,9 @@
         }
       },
       {
+        "codeSnippet": {
+          "javascript": "zP712rSHdkQ3"
+        },
         "name": "createBatch",
         "summary": "Create a batch of unique NFTs to be claimed in the future\n\n",
         "remarks": "\n\nCreate batch allows you to create a batch of many unique NFTs in one transaction.\n\n",

--- a/docs/snippets.json
+++ b/docs/snippets.json
@@ -2437,9 +2437,6 @@
     "name": "ContractDeployer",
     "summary": "Handles deploying new contracts\n\n\n",
     "examples": {},
-    "codeSnippet": {
-      "javascript": "2quu7XPcHpmB"
-    },
     "methods": [
       {
         "name": "deployEdition",
@@ -2562,7 +2559,7 @@
       },
       {
         "codeSnippet": {
-          "javascript": "VUSQyKVLudnM"
+          "javascript": "Hq0FmpRimr2k"
         },
         "name": "deploySignatureDrop",
         "summary": "Deploys a new SignatureDrop contract\n\n",
@@ -3125,13 +3122,13 @@
   },
   "SignatureDrop": {
     "name": "SignatureDrop",
-    "summary": "Setup a collection of NFTs wheref when it comes to minting, you can authorize some external party to mint tokens on your contract, and specify what exactly will be minted by that external party..\n\n",
+    "summary": "Setup a collection of NFTs where when it comes to minting, you can authorize some external party to mint tokens on your contract, and specify what exactly will be minted by that external party..\n\n",
     "examples": {
-      "javascript": "import { ThirdwebSDK } from \"@thirdweb-dev/sdk\";\n\nconst sdk = new ThirdwebSDK(process.env.chain_name);\nconst contract = sdk.getSignatureDrop(process.env.contract_address);",
+      "javascript": "import { ThirdwebSDK } from \"@thirdweb-dev/sdk\";\n\nconst sdk = new ThirdwebSDK(\"{{chainName}}\");\nconst contract = sdk.getSignatureDrop(\"{{contract_address}}\");",
       "react": "import { useSignatureDrop } from '@thirdweb-dev/react'\n\nexport default function Component() {\n  const signatureDrop = useSignatureDrop(\"<YOUR-CONTRACT-ADDRESS>\")\n\n  // Now you can use the Signature drop contract in the rest of the component\n}"
     },
     "codeSnippet": {
-      "javascript": "iuj78ZjwlEcv"
+      "javascript": "dtZiJZbEqHzZ"
     },
     "methods": [
       {
@@ -3170,7 +3167,7 @@
       },
       {
         "codeSnippet": {
-          "javascript": "zP712rSHdkQ3"
+          "javascript": "M7ZkiT8z1b4K"
         },
         "name": "createBatch",
         "summary": "Create a batch of unique NFTs to be claimed in the future\n\n",
@@ -3344,6 +3341,9 @@
     ],
     "properties": [
       {
+        "codeSnippet": {
+          "javascript": "gpJJOkEMvwTm"
+        },
         "name": "claimConditions",
         "summary": "Configure claim conditions\n\n",
         "remarks": "\n\nDefine who can claim NFTs in the collection, when and how many.\n\n",
@@ -3361,6 +3361,9 @@
         }
       },
       {
+        "codeSnippet": {
+          "javascript": "a5HSDvbAI44c"
+        },
         "name": "revealer",
         "summary": "Delayed reveal\n\n",
         "remarks": "\n\nCreate a batch of encrypted NFTs that can be revealed at a later time.\n\n",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier": "prettier --write '(docs|guides|blog)/**/*.{js,jsx,ts,tsx,md,mdx}'"
   },
   "dependencies": {
+    "@devbookhq/react": "^1.1.5",
     "@docusaurus/core": "^2.0.1",
     "@docusaurus/plugin-content-docs": "^2.0.1",
     "@docusaurus/plugin-ideal-image": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier": "prettier --write '(docs|guides|blog)/**/*.{js,jsx,ts,tsx,md,mdx}'"
   },
   "dependencies": {
-    "@devbookhq/react": "^1.1.7",
+    "@devbookhq/react": "^1.1.9",
     "@docusaurus/core": "^2.0.1",
     "@docusaurus/plugin-content-docs": "^2.0.1",
     "@docusaurus/plugin-ideal-image": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier": "prettier --write '(docs|guides|blog)/**/*.{js,jsx,ts,tsx,md,mdx}'"
   },
   "dependencies": {
-    "@devbookhq/react": "^1.1.5",
+    "@devbookhq/react": "^1.1.7",
     "@docusaurus/core": "^2.0.1",
     "@docusaurus/plugin-content-docs": "^2.0.1",
     "@docusaurus/plugin-ideal-image": "^2.0.1",

--- a/src/components/ThirdwebCodeSnippet.tsx
+++ b/src/components/ThirdwebCodeSnippet.tsx
@@ -120,7 +120,7 @@ export default function ThirdwebCodeSnippet({
           }
 
           let codeSnippetID: string | undefined;
-          let connectCodeSnippetIDs: string[] | undefined;
+          let connectCodeSnippetIDs: string[] = [];
 
           if (isGetContractCode && contractObject.codeSnippet) {
             codeSnippetID = contractObject.codeSnippet[language];
@@ -129,10 +129,16 @@ export default function ThirdwebCodeSnippet({
             if (contractObject.codeSnippet) {
               const contractCodeSnippetID = contractObject.codeSnippet[language];
               if (contractCodeSnippetID) {
-                connectCodeSnippetIDs = [contractCodeSnippetID];
+                connectCodeSnippetIDs.push(contractCodeSnippetID);
               }
             }
           }
+
+          const baseCodeSnippetID = 'Hq0FmpRimr2k';
+          if (codeSnippetID !== baseCodeSnippetID) {
+            connectCodeSnippetIDs.unshift(baseCodeSnippetID);
+          }
+
 
           let fallbackLanguage: Language;
 
@@ -150,8 +156,8 @@ export default function ThirdwebCodeSnippet({
             <TabItem key={language} value={language} label={languageName}>
               <CodeSnippet
                 id={codeSnippetID}
+                // isEditable={!!codeSnippetID}
                 connectIDs={connectCodeSnippetIDs}
-                isEditable={!!codeSnippetID}
                 fallbackContent={example}
                 fallbackLanguage={fallbackLanguage}
               />

--- a/src/components/ThirdwebCodeSnippet.tsx
+++ b/src/components/ThirdwebCodeSnippet.tsx
@@ -4,6 +4,7 @@ import featureJsonData from "../../docs/feature_snippets.json";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from "@theme/CodeBlock";
+import { CodeSnippet, Language } from '@devbookhq/react'
 
 export default function ThirdwebCodeSnippet({
   contract,
@@ -15,11 +16,11 @@ export default function ThirdwebCodeSnippet({
   languages = {},
 }) {
   const languagesToShow = {
-    react: true,
+    // react: true,
     javascript: true,
-    python: true,
-    go: true,
-    ...languages
+    // python: true,
+    // go: true,
+    // ...languages
   };
 
   if (!contract || !name) {
@@ -58,7 +59,11 @@ export default function ThirdwebCodeSnippet({
     codeObjectToUse = propertyOrMethodFallback;
   }
 
-  const { examples, reference: references } = codeObjectToUse;
+  const {
+    examples,
+    reference: references,
+    codeSnippet,
+  } = codeObjectToUse;
 
   const languageToHighlightMapping = {
     javascript: "typescript",
@@ -69,7 +74,7 @@ export default function ThirdwebCodeSnippet({
 
   return (
     <>
-      <Tabs groupId={groupId} defaultValue={"react"}>
+      <Tabs groupId={groupId} defaultValue={"javascript"}>
         {Object.entries(languagesToShow).map(([language, alwaysShow]) => {
           const example = examples[language];
           const reference = references[language];
@@ -114,11 +119,42 @@ export default function ThirdwebCodeSnippet({
             );
           }
 
+          let codeSnippetID: string | undefined;
+          let connectCodeSnippetIDs: string[] | undefined;
+
+          if (isGetContractCode && contractObject.codeSnippet) {
+            codeSnippetID = contractObject.codeSnippet[language];
+          } else if (!isGetContractCode && codeSnippet) {
+            codeSnippetID = codeSnippet[language];
+            if (contractObject.codeSnippet) {
+              const contractCodeSnippetID = contractObject.codeSnippet[language];
+              if (contractCodeSnippetID) {
+                connectCodeSnippetIDs = [contractCodeSnippetID];
+              }
+            }
+          }
+
+          let fallbackLanguage: Language;
+
+          if (languageName === "javascript") {
+            fallbackLanguage = "Typescript";
+          } else if (languageName === "go") {
+            fallbackLanguage = "Go";
+          } else if (languageName === 'react') {
+            fallbackLanguage = "Typescript";
+          } else if (languageName === 'python') {
+            fallbackLanguage = "Python3";
+          }
+
           return (
             <TabItem key={language} value={language} label={languageName}>
-              <CodeBlock language={languageToHighlightMapping[language]}>
-                {example}
-              </CodeBlock>
+              <CodeSnippet
+                id={codeSnippetID}
+                connectIDs={connectCodeSnippetIDs}
+                isEditable={!!codeSnippetID}
+                fallbackContent={example}
+                fallbackLanguage={fallbackLanguage}
+              />
 
               {reference && (
                 <a

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -10,6 +10,7 @@ import DocItemTOCMobile from "@theme/DocItem/TOC/Mobile";
 import DocItemTOCDesktop from "@theme/DocItem/TOC/Desktop";
 import DocItemContent from "@theme/DocItem/Content";
 import DocBreadcrumbs from "@theme/DocBreadcrumbs";
+import { SharedSessionProvider as DevbookSessionProvider } from "@devbookhq/react"
 import styles from "./styles.module.css";
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
@@ -31,6 +32,9 @@ function useDocTOC() {
     desktop,
   };
 }
+
+const baseCodeSnippetID = "Hq0FmpRimr2k"
+
 export default function DocItemLayout({ children }) {
   const docTOC = useDocTOC();
   return (
@@ -42,7 +46,9 @@ export default function DocItemLayout({ children }) {
             {/* <DocBreadcrumbs /> */}
             <DocVersionBadge />
             {docTOC.mobile}
-            <DocItemContent>{children}</DocItemContent>
+            <DevbookSessionProvider opts={{ codeSnippetID: baseCodeSnippetID }}>
+              <DocItemContent>{children}</DocItemContent>
+            </DevbookSessionProvider>
             <DocItemFooter />
           </article>
           <DocItemPaginator />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,10 +1324,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@devbookhq/react@^1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@devbookhq/react/-/react-1.1.7.tgz#1da3c2f4ba77fd34aea904ed43b81045c1c93380"
-  integrity sha512-KP6324mc+5ZwqPrGOq/BDKqSFB5ECOblkKc4rtjoa3YFGGbzaT4HWfx+pwHIZSpntVjmfKICyC1Tkv5Pngq8+A==
+"@devbookhq/react@^1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@devbookhq/react/-/react-1.1.9.tgz#97d854a2a5c57ff164029aae0f455c47446a7d5c"
+  integrity sha512-KHkKUxj+OvTblIiDTSliwEts0CzWAb2M5jucX7GSNCsthjHgcVWZYqRzr9NzdCy8x1sFGe/Ha+O1KceHyZhrdQ==
   dependencies:
     "@codemirror/closebrackets" "^0.19.1"
     "@codemirror/commands" "^0.19.8"
@@ -1342,14 +1342,14 @@
     "@codemirror/state" "^0.19.9"
     "@codemirror/stream-parser" "^0.19.7"
     "@codemirror/view" "^0.19.47"
-    "@devbookhq/sdk" "^2.4.4"
+    "@devbookhq/sdk" "^2.4.5"
     classnames "^2.3.1"
     react-idle-timer "^5.4.1"
 
-"@devbookhq/sdk@^2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@devbookhq/sdk/-/sdk-2.4.4.tgz#dc168dba48f075904fc461c2074e6b3ce4922352"
-  integrity sha512-hbLKhRYoQ+QUdMeHMtqX3EA/nsg8TSv+Lfd+m8XW55zM+Coy6e8FF01l7RWSX9a1SxNpIEFuz/b5fQQrRAxNkg==
+"@devbookhq/sdk@^2.4.5":
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/@devbookhq/sdk/-/sdk-2.4.5.tgz#be5919289b3b5d8eff541da899b75840afb927e3"
+  integrity sha512-CCkFc90XdIIUOklXq7GAAvWm5Y/17grLWYTepD7UOfrre0jtJPvZx3BCBxZo1pFIchWxGaDoPyWgP9ZYqHhrQw==
   dependencies:
     cross-fetch "^3.1.5"
     openapi-typescript-fetch "^1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,10 +1324,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@devbookhq/react@^1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@devbookhq/react/-/react-1.1.5.tgz#2ce20875614272dcfba9fdf3ce4ec49a3a7a10e9"
-  integrity sha512-OAMeBOeFZ2zMjN1+T5yNcRbTkGvmfkyU/V8x/u2zzJTbOQRyg1j2RAyJ4z4wqbZtPh0hAyOi9onrap2k7/qSew==
+"@devbookhq/react@^1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@devbookhq/react/-/react-1.1.7.tgz#1da3c2f4ba77fd34aea904ed43b81045c1c93380"
+  integrity sha512-KP6324mc+5ZwqPrGOq/BDKqSFB5ECOblkKc4rtjoa3YFGGbzaT4HWfx+pwHIZSpntVjmfKICyC1Tkv5Pngq8+A==
   dependencies:
     "@codemirror/closebrackets" "^0.19.1"
     "@codemirror/commands" "^0.19.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,10 +1177,183 @@
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
+"@codemirror/closebrackets@^0.19.1":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/closebrackets/-/closebrackets-0.19.2.tgz#ff74dd78218cee57172623eb9ebf7b669fa6f4d4"
+  integrity sha512-ClMPzPcPP0eQiDcVjtVPl6OLxgdtZSYDazsvT0AKl70V1OJva0eHgl4/6kCW3RZ0pb2n34i9nJz4eXCmK+TYDA==
+  dependencies:
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.2"
+    "@codemirror/text" "^0.19.0"
+    "@codemirror/view" "^0.19.44"
+
+"@codemirror/commands@^0.19.8":
+  version "0.19.8"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-0.19.8.tgz#1f99c1a8bf200d17c4d6997379099459f3678107"
+  integrity sha512-65LIMSGUGGpY3oH6mzV46YWRrgao6NmfJ+AuC7jNz3K5NPnH6GCV1H5I6SwOFyVbkiygGyd0EFwrWqywTBD1aw==
+  dependencies:
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/matchbrackets" "^0.19.0"
+    "@codemirror/state" "^0.19.2"
+    "@codemirror/text" "^0.19.6"
+    "@codemirror/view" "^0.19.22"
+    "@lezer/common" "^0.15.0"
+
+"@codemirror/comment@^0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/comment/-/comment-0.19.1.tgz#7def8345eeb9095ef1ef33676fbde1ab4fe33fad"
+  integrity sha512-uGKteBuVWAC6fW+Yt8u27DOnXMT/xV4Ekk2Z5mRsiADCZDqYvryrJd6PLL5+8t64BVyocwQwNfz1UswYS2CtFQ==
+  dependencies:
+    "@codemirror/state" "^0.19.9"
+    "@codemirror/text" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/fold@^0.19.3":
+  version "0.19.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/fold/-/fold-0.19.4.tgz#f2a17e508378d5a83dc587ed6f1a635969219a2b"
+  integrity sha512-0SNSkRSOa6gymD6GauHa3sxiysjPhUC0SRVyTlvL52o0gz9GHdc8kNqNQskm3fBtGGOiSriGwF/kAsajRiGhVw==
+  dependencies:
+    "@codemirror/gutter" "^0.19.0"
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.22"
+
+"@codemirror/gutter@^0.19.0", "@codemirror/gutter@^0.19.9":
+  version "0.19.9"
+  resolved "https://registry.yarnpkg.com/@codemirror/gutter/-/gutter-0.19.9.tgz#bbb69f4d49570d9c1b3f3df5d134980c516cd42b"
+  integrity sha512-PFrtmilahin1g6uL27aG5tM/rqR9DZzZYZsIrCXA5Uc2OFTFqx4owuhoU9hqfYxHp5ovfvBwQ+txFzqS4vog6Q==
+  dependencies:
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.23"
+
+"@codemirror/highlight@^0.19.0", "@codemirror/highlight@^0.19.7":
+  version "0.19.8"
+  resolved "https://registry.yarnpkg.com/@codemirror/highlight/-/highlight-0.19.8.tgz#a95aee8ae4389b01f820aa79c48f7b4388087d92"
+  integrity sha512-v/lzuHjrYR8MN2mEJcUD6fHSTXXli9C1XGYpr+ElV6fLBIUhMTNKR3qThp611xuWfXfwDxeL7ppcbkM/MzPV3A==
+  dependencies:
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/rangeset" "^0.19.0"
+    "@codemirror/state" "^0.19.3"
+    "@codemirror/view" "^0.19.39"
+    "@lezer/common" "^0.15.0"
+    style-mod "^4.0.0"
+
+"@codemirror/history@^0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/history/-/history-0.19.2.tgz#25e3fda755f77ac1223a6ae6e9d7899f5919265e"
+  integrity sha512-unhP4t3N2smzmHoo/Yio6ueWi+il8gm9VKrvi6wlcdGH5fOfVDNkmjHQ495SiR+EdOG35+3iNebSPYww0vN7ow==
+  dependencies:
+    "@codemirror/state" "^0.19.2"
+    "@codemirror/view" "^0.19.0"
+
+"@codemirror/language@^0.19.0", "@codemirror/language@^0.19.8":
+  version "0.19.10"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-0.19.10.tgz#c3d1330fa5de778c6b6b5177af5572a3d9d596b5"
+  integrity sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==
+  dependencies:
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/text" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+    "@lezer/common" "^0.15.5"
+    "@lezer/lr" "^0.15.0"
+
+"@codemirror/legacy-modes@^0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/legacy-modes/-/legacy-modes-0.19.1.tgz#7dc3b5df1842060648f75764ab6919fcfce3ea1a"
+  integrity sha512-vYPLsD/ON+3SXhlGj9Qb3fpFNNU3Ya/AtDiv/g3OyqVzhh5vs5rAnOvk8xopGWRwppdhlNPD9VyXjiOmZUQtmQ==
+  dependencies:
+    "@codemirror/stream-parser" "^0.19.0"
+
+"@codemirror/matchbrackets@^0.19.0", "@codemirror/matchbrackets@^0.19.4":
+  version "0.19.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/matchbrackets/-/matchbrackets-0.19.4.tgz#50b5188eb2d53f32598dca906bf5fd66626a9ebc"
+  integrity sha512-VFkaOKPNudAA5sGP1zikRHCEKU0hjYmkKpr04pybUpQvfTvNJXlReCyP0rvH/1iEwAGPL990ZTT+QrLdu4MeEA==
+  dependencies:
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/view" "^0.19.0"
+    "@lezer/common" "^0.15.0"
+
+"@codemirror/rangeset@^0.19.0", "@codemirror/rangeset@^0.19.5":
+  version "0.19.9"
+  resolved "https://registry.yarnpkg.com/@codemirror/rangeset/-/rangeset-0.19.9.tgz#e80895de93c39dc7899f5be31d368c9d88aa4efc"
+  integrity sha512-V8YUuOvK+ew87Xem+71nKcqu1SXd5QROMRLMS/ljT5/3MCxtgrRie1Cvild0G/Z2f1fpWxzX78V0U4jjXBorBQ==
+  dependencies:
+    "@codemirror/state" "^0.19.0"
+
+"@codemirror/state@^0.19.0", "@codemirror/state@^0.19.2", "@codemirror/state@^0.19.3", "@codemirror/state@^0.19.9":
+  version "0.19.9"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-0.19.9.tgz#b797f9fbc204d6dc7975485e231693c09001b0dd"
+  integrity sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==
+  dependencies:
+    "@codemirror/text" "^0.19.0"
+
+"@codemirror/stream-parser@^0.19.0", "@codemirror/stream-parser@^0.19.7":
+  version "0.19.9"
+  resolved "https://registry.yarnpkg.com/@codemirror/stream-parser/-/stream-parser-0.19.9.tgz#34955ea91a8047cf72abebd5ce28f0d332aeca48"
+  integrity sha512-WTmkEFSRCetpk8xIOvV2yyXdZs3DgYckM0IP7eFi4ewlxWnJO/H4BeJZLs4wQaydWsAqTQoDyIwNH1BCzK5LUQ==
+  dependencies:
+    "@codemirror/highlight" "^0.19.0"
+    "@codemirror/language" "^0.19.0"
+    "@codemirror/state" "^0.19.0"
+    "@codemirror/text" "^0.19.0"
+    "@lezer/common" "^0.15.0"
+    "@lezer/lr" "^0.15.0"
+
+"@codemirror/text@^0.19.0", "@codemirror/text@^0.19.6":
+  version "0.19.6"
+  resolved "https://registry.yarnpkg.com/@codemirror/text/-/text-0.19.6.tgz#9adcbd8137f69b75518eacd30ddb16fd67bbac45"
+  integrity sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA==
+
+"@codemirror/view@^0.19.0", "@codemirror/view@^0.19.22", "@codemirror/view@^0.19.23", "@codemirror/view@^0.19.39", "@codemirror/view@^0.19.44", "@codemirror/view@^0.19.47":
+  version "0.19.48"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-0.19.48.tgz#1c657e2b0f8ed896ac6448d6e2215ab115e2a0fc"
+  integrity sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==
+  dependencies:
+    "@codemirror/rangeset" "^0.19.5"
+    "@codemirror/state" "^0.19.3"
+    "@codemirror/text" "^0.19.0"
+    style-mod "^4.0.0"
+    w3c-keyname "^2.2.4"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
+"@devbookhq/react@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@devbookhq/react/-/react-1.1.5.tgz#2ce20875614272dcfba9fdf3ce4ec49a3a7a10e9"
+  integrity sha512-OAMeBOeFZ2zMjN1+T5yNcRbTkGvmfkyU/V8x/u2zzJTbOQRyg1j2RAyJ4z4wqbZtPh0hAyOi9onrap2k7/qSew==
+  dependencies:
+    "@codemirror/closebrackets" "^0.19.1"
+    "@codemirror/commands" "^0.19.8"
+    "@codemirror/comment" "^0.19.1"
+    "@codemirror/fold" "^0.19.3"
+    "@codemirror/gutter" "^0.19.9"
+    "@codemirror/highlight" "^0.19.7"
+    "@codemirror/history" "^0.19.2"
+    "@codemirror/language" "^0.19.8"
+    "@codemirror/legacy-modes" "^0.19.1"
+    "@codemirror/matchbrackets" "^0.19.4"
+    "@codemirror/state" "^0.19.9"
+    "@codemirror/stream-parser" "^0.19.7"
+    "@codemirror/view" "^0.19.47"
+    "@devbookhq/sdk" "^2.4.4"
+    classnames "^2.3.1"
+    react-idle-timer "^5.4.1"
+
+"@devbookhq/sdk@^2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@devbookhq/sdk/-/sdk-2.4.4.tgz#dc168dba48f075904fc461c2074e6b3ce4922352"
+  integrity sha512-hbLKhRYoQ+QUdMeHMtqX3EA/nsg8TSv+Lfd+m8XW55zM+Coy6e8FF01l7RWSX9a1SxNpIEFuz/b5fQQrRAxNkg==
+  dependencies:
+    cross-fetch "^3.1.5"
+    openapi-typescript-fetch "^1.1.3"
+    rpc-websocket-client "^1.1.4"
 
 "@docsearch/css@3.2.1":
   version "3.2.1"
@@ -1707,6 +1880,18 @@
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
+
+"@lezer/common@^0.15.0", "@lezer/common@^0.15.5":
+  version "0.15.12"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-0.15.12.tgz#2f21aec551dd5fd7d24eb069f90f54d5bc6ee5e9"
+  integrity sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==
+
+"@lezer/lr@^0.15.0":
+  version "0.15.8"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-0.15.8.tgz#1564a911e62b0a0f75ca63794a6aa8c5dc63db21"
+  integrity sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==
+  dependencies:
+    "@lezer/common" "^0.15.0"
 
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"
@@ -2985,6 +3170,11 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 clean-css@^5.2.2, clean-css@^5.3.0:
   version "5.3.1"
@@ -4914,6 +5104,11 @@ isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
+isomorphic-ws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
+  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+
 jest-worker@^27.4.5, jest-worker@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz#8d146f0900e8973b106b6f73cc1e9a8cb86f8db0"
@@ -5534,6 +5729,11 @@ open@^8.0.9, open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+openapi-typescript-fetch@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/openapi-typescript-fetch/-/openapi-typescript-fetch-1.1.3.tgz#354e6803b7885c7142ae11adc1b758afafd8aa2e"
+  integrity sha512-smLZPck4OkKMNExcw8jMgrMOGgVGx2N/s6DbKL2ftNl77g5HfoGpZGFy79RBzU/EkaO0OZpwBnslfdBfh7ZcWg==
 
 opener@^1.5.2:
   version "1.5.2"
@@ -6315,6 +6515,11 @@ react-helmet-async@*, react-helmet-async@^1.3.0:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
+react-idle-timer@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/react-idle-timer/-/react-idle-timer-5.4.1.tgz#4f05e5d2a41656e78fb78a30a4bc232d3964b8f5"
+  integrity sha512-Pn0ede5OBeUxkIdnGevKAcVtdMnzRzFgBI6k2DC3gDbDCqRSePblxKH6Lbb0ncLzwaw9hnZfe3/Z8Bj1HA8khA==
+
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -6659,6 +6864,15 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rpc-websocket-client@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/rpc-websocket-client/-/rpc-websocket-client-1.1.4.tgz#c82a98c85a4a3ed65b19cf7fe989bf8cbfd5b421"
+  integrity sha512-UDMVcsNDJ3WET+0EFdmseYX+60MOCA3BpgpZ5dbtiGsqHo+9uWfgNbPZ4iGDtNcX+EUhCt/Y7C0fTmUU3CkkWA==
+  dependencies:
+    isomorphic-ws "^4.0.1"
+    uuid "^3.3.3"
+    ws "^7.1.2"
 
 rrweb-snapshot@^1.1.14:
   version "1.1.14"
@@ -7196,6 +7410,11 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+style-mod@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.0.0.tgz#97e7c2d68b592975f2ca7a63d0dd6fcacfe35a01"
+  integrity sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==
+
 style-to-object@0.3.0, style-to-object@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
@@ -7644,6 +7863,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^3.3.3:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -7681,6 +7905,11 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.6.tgz#8412046116bc16c5d73d4e612053ea10a189c85f"
+  integrity sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==
 
 wait-on@^6.0.1:
   version "6.0.1"
@@ -7920,7 +8149,7 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.3.1:
+ws@^7.1.2, ws@^7.3.1:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==


### PR DESCRIPTION
In this PR we made the first 5 examples on the `/sdk/interacting-with-contracts/signature-drop` route runnable.

They use Devbook's code snippets from our dashboard and `CodeSnippet` component from our NPM package `@devbookhq/react` for connecting and displaying the code and results.

I integrated with your `snippets.json` system - you now specify our code snippet's ID alongside the example's content in your `snippets.json` and your code in the example is also used as a fallback.
