### PR TITLE
Quick copy fixes for Signature Drop portal page

### DIFF
--- a/docs/onboarding/1 Pre-Built Contracts/2EVM/1 3 NFT/1 3 1 Signature Drop.mdx
+++ b/docs/onboarding/1 Pre-Built Contracts/2EVM/1 3 NFT/1 3 1 Signature Drop.mdx
@@ -20,15 +20,13 @@ import YoutubeEmbed from "@components/YoutubeEmbed";
   <div>
     <p>
       The Signature Drop contract uses the{" "}
-      <a href="https://www.erc721a.org/">ERC721A</a>
+      <a href="https://www.erc721a.org/">ERC721A</a> 
       standard to release a collection of unique one-of-one NFTs with lower gas fees
       for your community compared to the regular ERC721 standard used in the <a href="https://portal.thirdweb.com/pre-built-contracts/nft-drop">
         NFT Drop
       </a>.
     </p>
-    You <b>lazy-mint</b> your NFTs by uploading the metadata and configuring a <b>
-      single
-    </b>
+    You <b>lazy-mint</b> your NFTs by uploading the metadata and configuring a <b>single</b> 
     claim phase, laying out the rules for how your users can claim NFTs from
     your drop; such as an allowlist, release date, or{" "}
     <a href="https://portal.thirdweb.com/sdk/advanced-features/delayed-reveal">


### PR DESCRIPTION
Added two spaces to intro paragraphs (not sure if I did correctly lol)

- 1st paragraph: "The Signature Drop contract uses the ERC721A [space] standard to release..."
- 2nd paragraph: "You lazy-mint your NFTs by uploading the metadata and configuring a single [space] claim phase..."