### PR TITLE
update: replace SmartContract into contract

### DIFF
--- a/docs/react/react.useallrolemembers.md
+++ b/docs/react/react.useallrolemembers.md
@@ -16,7 +16,7 @@ Use this to get the roles of a
 ## Example
 
 ```jsx
-const { data: roles, isLoading, error } = useAllRoleMembers(SmartContract);
+const { data: roles, isLoading, error } = useAllRoleMembers(contract);
 ```
 
 **Signature:**

--- a/docs/react/react.usegrantrole.md
+++ b/docs/react/react.usegrantrole.md
@@ -17,7 +17,7 @@ Use this to grant a [WalletAddress](./react.walletaddress.md) a specific role on
 
 ```jsx
 const Component = () => {
-  const { mutate: grantRole, isLoading, error } = useGrantRole(SmartContract);
+  const { mutate: grantRole, isLoading, error } = useGrantRole(contract);
 
   if (error) {
     console.error("failed to grant role", error);

--- a/docs/react/react.useisaddressrole.md
+++ b/docs/react/react.useisaddressrole.md
@@ -20,7 +20,7 @@ const {
   data: isMember,
   isLoading,
   error,
-} = useIsAddressRole(SmartContract, "admin", "0x123");
+} = useIsAddressRole(contract, "admin", "0x123");
 ```
 
 **Signature:**

--- a/docs/react/react.userevokerole.md
+++ b/docs/react/react.userevokerole.md
@@ -17,7 +17,7 @@ Use this to revoke a [WalletAddress](./react.walletaddress.md) a specific role o
 
 ```jsx
 const Component = () => {
-  const { mutate: revokeRole, isLoading, error } = useRevokeRole(SmartContract);
+  const { mutate: revokeRole, isLoading, error } = useRevokeRole(contract);
 
   if (error) {
     console.error("failed to revoke role", error);

--- a/docs/react/react.userolemembers.md
+++ b/docs/react/react.userolemembers.md
@@ -20,7 +20,7 @@ const {
   data: members,
   isLoading,
   error,
-} = useRoleMembers(SmartContract, "admin");
+} = useRoleMembers(contract, "admin");
 ```
 
 **Signature:**

--- a/docs/react/react.usesetallrolemembers.md
+++ b/docs/react/react.usesetallrolemembers.md
@@ -21,7 +21,7 @@ const Component = () => {
     mutate: overwriteRoles,
     isLoading,
     error,
-  } = useSetAllRoleMembers(SmartContract);
+  } = useSetAllRoleMembers(contract);
 
   if (error) {
     console.error("failed to overwrite roles", error);


### PR DESCRIPTION
`SmartContract` is referring to `contract` object as referenced below.

```js
const { contract } = useContract("<CONTRACT_ADDRESS>");
```

## Changes

- Replaced `SmartContract` with `contract` under `Permission Controls` via React SDK.

---

Not sure with the update if we stick to `SmartContract` or `contract`
This can cause confusion if it is not consistent.

Any thoughts @joaquim-verges @jarrodwatts @jnsdls ?