### PR TITLE
Remove ZeroAddress from to address

### DIFF
--- a/docs/typescript/sdk.erc1155signaturemintable.generatefromtokenid.md
+++ b/docs/typescript/sdk.erc1155signaturemintable.generatefromtokenid.md
@@ -24,7 +24,7 @@ const startTime = new Date();
 const endTime = new Date(Date.now() + 60 * 60 * 24 * 1000);
 const payload = {
   tokenId: 0, // Instead of metadata, we specificy the token ID of the NFT to mint supply to
-  to: {{wallet_address}}, // Who will receive the NFT (or AddressZero for anyone)
+  to: {{wallet_address}}, // Who will receive the NFT
   quantity: 2, // the quantity of NFTs to mint
   price: 0.5, // the price per NFT
   currencyAddress: NATIVE_TOKEN_ADDRESS, // the currency to pay with


### PR DESCRIPTION
Remove ZeroAddress from to address. You can no longer specify the to address as the zero address (i.e. you can't create a payload that anyone can mint anymore)