### PR TITLE
Update Unity SDK FundWallet guide

### DIFF
--- a/docs/onboarding/9 Gaming/5 Wallet Actions/2 Fund Wallet.mdx
+++ b/docs/onboarding/9 Gaming/5 Wallet Actions/2 Fund Wallet.mdx
@@ -45,7 +45,7 @@ Use the `FundWallet` method to begin the following flow:
 
 ```csharp
 // Call the "FundWallet" function to trigger the Coinbase Pay flow.
-await sdk.FundWallet(new FundWalletOptions() {
+await sdk.wallet.FundWallet(new FundWalletOptions() {
     appId = "<your-app-id-here>", // https://docs.cloud.coinbase.com/pay-sdk/docs/using-sdk
     address = address, // The wallet address to fund
     chainId = 137 // The chain ID of the network to fund


### PR DESCRIPTION
Update code snippet for accuracy.

Context: `FundWallet` is a method of `Thirdweb.Wallet` rather than a top level method in the namespace.