### PR TITLE
distribute releases ether if no token addr param

### DIFF
--- a/docs/contracts/Split.md
+++ b/docs/contracts/Split.md
@@ -83,7 +83,7 @@ _Release owed amount of the `token` to all of the payees._
 function distribute() external nonpayable
 ```
 
-_Release the owed amount of token to all of the payees._
+_Release the owed amount of ether to all of the payees._
 
 ### getRoleAdmin
 


### PR DESCRIPTION
there was [a comment in discord](https://discord.com/channels/834227967404146718/1093170667475709953/1093445740971429990) where the user was confused about how to distribute ether. The docs could be a bit clearer about the description of the function that is responsible to do this by matching the language in the docs to the comments of the .sol file:
<img width="1309" alt="Screen Shot 2023-04-06 at 8 20 58 AM" src="https://user-images.githubusercontent.com/89474773/230377691-9f4c8075-df62-49e8-82a3-86b869108072.png">
