### PR TITLE
Updated 2 out of 4 Dead links on ERC1155Drop.mdx

### DIFF
--- a/docs/onboarding/1 Solidity SDK/Base Contracts/ERC1155/ERC1155Drop.mdx
+++ b/docs/onboarding/1 Solidity SDK/Base Contracts/ERC1155/ERC1155Drop.mdx
@@ -13,8 +13,8 @@ import "@thirdweb-dev/contracts/base/ERC1155Drop.sol";
 
 The `ERC1155Drop` base contract is the foundation for an Edition (ERC1155) NFT Drop that other wallets can claim.
 
-It implements the [ERC1155 standard](/solidity/erc1155) with [Lazy Mint](/solidity/extensions/erc1155lazymint),
-[Delayed Reveal](/solidity/extensions/delayedreveal) and [Drop](/solidity/extensions/1155dropsignlephase) extensions;
+It implements the [ERC1155 standard](/solidity/extensions/erc1155) with [Lazy Mint](/solidity/extensions/erc1155lazymint),
+[Delayed Reveal](/solidity/extensions/delayedreveal) and [Drop](/solidity/extensions/erc1155dropsinglephase) extensions;
 allowing you to batch lazy-mint NFTs, and allow other wallets to claim them under the criteria of claim conditions, with an optional delayed reveal.
 
 <ViewContractCodeButton


### PR DESCRIPTION
Lazy mint link is still dead. I wasn't sure if it should link to
 '/solidity/base-contracts/erc1155lazymint' or '/solidity/extensions/lazymint'

Also ERC1155LazyMintableV2 is a dead link. Its page might be missing.