### PR TITLE
Smart contract links to missing page.

### DIFF
--- a/docs/onboarding/15 Glossary/Gas Fees.mdx
+++ b/docs/onboarding/15 Glossary/Gas Fees.mdx
@@ -14,7 +14,7 @@ While using thirdweb is free, you will need to cover the cost of performing acti
 
 This includes actions performed via the thirdweb dashboard, our SDKs, or any of our other products, including:
 
-- Deploying [smart contracts](/glossary/smart-contracts)
+- Deploying smart contracts
 - [Lazy-minting](/glossary/lazy-minting) the metadata of your NFTs
 - Updating permissions on your smart contracts
 - Setting [claim phases](/glossary/claim-phases)


### PR DESCRIPTION
Looks like the smart contract page is missing.  Removed the link until the page exists.