### PR TITLE
remove token ID as a parameter for erc721 claiming

### DIFF
--- a/docs/typescript/interacting-with-contracts/prebuilt-contracts/nft-drop.mdx
+++ b/docs/typescript/interacting-with-contracts/prebuilt-contracts/nft-drop.mdx
@@ -184,7 +184,7 @@ There are three options available:
 - `pricePerToken` - The price to pay for each token claimed. Not relevant when using claim conditions.
 
 ```javascript
-const txResult = await contract.erc721.claim("{{token_id}}", "{{quantity}}", {
+const txResult = await contract.erc721.claim("{{quantity}}", {
   checkERC20Allowance: true,
   currencyAddress: "{{currency_contract_address}}",
   pricePerToken: "{{price}}",


### PR DESCRIPTION
I believe that the token ID parameter was included by error. I would like that feature available where users can choose which token ID to mint from but I don't believe the standard ERC-721 drop contract supports that based on [this thread from the discord](https://discord.com/channels/834227967404146718/834227967404146721/1076627821922877571).