### PR TITLE
Updated Dead links

### DIFF
--- a/docs/onboarding/14 Wallet/0 Overview.mdx
+++ b/docs/onboarding/14 Wallet/0 Overview.mdx
@@ -15,7 +15,7 @@ and integrates with our [SDK](/sdk) to use the connected wallet
 to interact with smart contracts, utilise [auth](/auth), [storage](/storage), and more.
 
 It supports a vast array of the most popular browser wallets such as [MetaMask](/wallet/metamask),
-[WalletConnect](/wallet/walletconnect) V1 and V2, [Coinbase Wallet](/wallet/coinbase-wallet), non-custodial wallets such as [Magic](/wallet/magic-link), multi-sig wallets such as [Safe (Gnosis)](/wallet/safe), 
+WalletConnect [V1](/wallet/wallet-connect-v1) and [V2](/wallet/wallet-connect-v2), [Coinbase Wallet](/wallet/coinbase-wallet), non-custodial wallets such as Magic and [Paper](/wallet/paper), multi-sig wallets such as [Safe (Gnosis)](/wallet/safe), 
 and more; each with fine-grained control over the connection flow to create customized experiences,
 or pre-built UI components to get you up and running quickly.
 


### PR DESCRIPTION
 Updated Dead links  and removed link to Magic link. The magic link page is missing. Also added link to the paper page.