### PR TITLE
removed link to non-existing hook on uselistings.mdx

### DIFF
--- a/docs/react/hooks/marketplace/uselistings.mdx
+++ b/docs/react/hooks/marketplace/uselistings.mdx
@@ -10,7 +10,7 @@ Hook for getting all listings (including expired ones) from a [Marketplace](http
 Note: this hook is only available for [Marketplace](https://thirdweb.com/thirdweb.eth/Marketplace) contracts.
 
 If you are using [Marketplace V3](https://thirdweb.com/thirdweb.eth/MarketplaceV3),
-use [useListingsV3](/react/react.useListingsV3) instead.
+use [useDirectListings](/react/react.usedirectlistings) or [useEnglishAuctions](/react/react.useenglishauctions) instead.
 
 :::
 


### PR DESCRIPTION
useListingsV3 hook doesn't exist updated to useDirectListings & useEnglishAuctions