### PR TITLE
Update docs/python/contract-deployer.mdx

### DIFF
--- a/docs/python/contract-deployer.mdx
+++ b/docs/python/contract-deployer.mdx
@@ -9,7 +9,7 @@ displayed_sidebar: python
 Deploy an [nft collection](/python/python.nftcollection) prebuilt contract.
 
 ```python
-from thirdweb.types.nft import NFTMetadataInput
+from thirdweb.types.settings.metadata import NFTCollectionContractMetadata
 
 metadata = NFTCollectionContractMetadata.from_json(
     {"name" : "my_nft_collection",

--- a/docs/python/contract-deployer.mdx
+++ b/docs/python/contract-deployer.mdx
@@ -11,7 +11,7 @@ Deploy an [nft collection](/python/python.nftcollection) prebuilt contract.
 ```python
 from thirdweb.types.nft import NFTMetadataInput
 
-metadata = NFTMetadataInput.from_json(
+metadata = NFTCollectionContractMetadata.from_json(
     {"name" : "my_nft_collection",
     #...
     }

--- a/docs/python/contract-deployer.mdx
+++ b/docs/python/contract-deployer.mdx
@@ -9,11 +9,12 @@ displayed_sidebar: python
 Deploy an [nft collection](/python/python.nftcollection) prebuilt contract.
 
 ```python
-from thirdweb.types.nft import NFTCollectionContractMetadata
+from thirdweb.types.nft import NFTMetadataInput
 
-metadata = NFTCollectionContractMetadata.from_json(
-    "name" : "my_nft_collection",
+metadata = NFTMetadataInput.from_json(
+    {"name" : "my_nft_collection",
     #...
+    }
 )
 contract.deploy_nft_collection(metadata)
 ```

--- a/docs/python/contract-deployer.mdx
+++ b/docs/python/contract-deployer.mdx
@@ -16,7 +16,7 @@ metadata = NFTMetadataInput.from_json(
     #...
     }
 )
-contract.deploy_nft_collection(metadata)
+contract.deployer.deploy_nft_collection(metadata)
 ```
 
 <details>
@@ -73,7 +73,7 @@ metadata = EditionContractMetadata.from_json(
     "name" : "my contract"
     # ...
 )
-sdk.deploy_edition(metadata)
+sdk.deployer.deploy_edition(metadata)
 ```
 
 <details>
@@ -130,7 +130,7 @@ metadata = TokenContractMetadata.from_json(
     "name" : "my contract"
     # ...
 )
-sdk.deploy_token(metadata)
+sdk.deployer.deploy_token(metadata)
 ```
 
 <details>
@@ -182,7 +182,7 @@ metadata = MarketplaceContractMetadata.from_json(
     "name" : "my contract"
     # ...
 )
-sdk.deploy_marketplace(metadata)
+sdk.deployer.deploy_marketplace(metadata)
 ```
 
 <details>
@@ -226,7 +226,7 @@ metadata = NFTDropContractMetadata.from_json(
     "name" : "my contract"
     # ...
 )
-sdk.deploy_nft_drop(metadata)
+sdk.deployer.deploy_nft_drop(metadata)
 ```
 
 <details>
@@ -287,7 +287,7 @@ metadata = EditionDropContractMetadata.from_json(
     "name" : "my contract"
     # ...
 )
-sdk.deploy_edition_drop(metadata)
+sdk.deployer.deploy_edition_drop(metadata)
 ```
 
 <details>
@@ -348,7 +348,7 @@ metadata = MultiwrapContractMetadata.from_json(
     "name" : "my contract"
     # ...
 )
-sdk.deploy_multiwrap(metadata)
+sdk.deployer.deploy_multiwrap(metadata)
 ```
 
 <details>

--- a/docs/python/contract-deployer.mdx
+++ b/docs/python/contract-deployer.mdx
@@ -16,7 +16,7 @@ metadata = NFTMetadataInput.from_json(
     #...
     }
 )
-contract.deployer.deploy_nft_collection(metadata)
+sdk.deployer.deploy_nft_collection(metadata)
 ```
 
 <details>


### PR DESCRIPTION
3 fixes to outdated docs for python contract deployer:

1. Updated deploy calls from sdk.deploy_[contractname] to sdk.deployer.deploy_[contractname]
2. Updated nft collection metadata input to correct NFTMetadataInput class.
3. Wrapped json contents in {} 

Note to devs: 2 and 3 likely need to be completed for other contract templates in this doc when staging metadata.

cc @joaquim-verges 