### PR TITLE
fix: cli package name

### DIFF
--- a/docs/onboarding/9 CLI/0 Overview.mdx
+++ b/docs/onboarding/9 CLI/0 Overview.mdx
@@ -28,13 +28,13 @@ _Note: If you do not wish to install it globally, you can prefix each command wi
 
 <Tabs>
   <TabItem value="npm" label="npm" default>
-    <CodeBlock language="bash">{`npm i -g @thirdweb-dev/cli`}</CodeBlock>
+    <CodeBlock language="bash">{`npm i -g thirdweb`}</CodeBlock>
   </TabItem>
   <TabItem value="yarn" label="yarn">
-    <CodeBlock language="bash">{`yarn global add @thirdweb-dev/cli`}</CodeBlock>
+    <CodeBlock language="bash">{`yarn global add thirdweb`}</CodeBlock>
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
-    <CodeBlock language="bash">{`pnpm install -g @thirdweb-dev/cli`}</CodeBlock>
+    <CodeBlock language="bash">{`pnpm install -g thirdweb`}</CodeBlock>
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
@joaquim-verges I updated the package name from `@thirdweb-dev/cli` to `thirdweb`

Looks like we are referencing an old package from here: https://www.npmjs.com/package/@thirdweb-dev/cli

Which is this is what we are currently using.
https://www.npmjs.com/package/thirdweb

Reported by a community member from Discord.