### PR TITLE
Adding Platformfees parameter while deploying pre-built contracts

### DIFF
--- a/docs/react/hooks/core/usesdk.mdx
+++ b/docs/react/hooks/core/usesdk.mdx
@@ -32,6 +32,9 @@ function App() {
     sdk?.deployer.deployNFTDrop({
       name: "My NFT Drop",
       primary_sale_recipient: "{{wallet_address}}",
+      platform_fee_basis_points: 100, // 1% platform fees
+      platform_fee_recipient: "{{wallet_address}}",
+
     });
   }
 }

--- a/docs/typescript/thirdwebsdk.sdk.contractdeployer.mdx
+++ b/docs/typescript/thirdwebsdk.sdk.contractdeployer.mdx
@@ -16,7 +16,10 @@ const txResult = await sdk.deployer.deployBuiltInContract(
   {
     name: "My Contract",
     primary_sale_recipient: "{{wallet_address}}",
+    platform_fee_basis_points: 100, // 1% platform fees
+    platform_fee_recipient: "{{wallet_address}}",
     voting_token_address: "{{wallet_address}}", // Only used for Vote
+    
   },
   version,
 );
@@ -65,10 +68,6 @@ An object containing the metadata for the contract to deploy.
   external_link: "https://example.com", // External link to view contract info on your website
   symbol: "MYCON", // Symbol of the contract tokens
   image: "https://some-image-here.png", // Image to use for the contract
-
-  // Optional Platform fee information
-  platform_fee_basis_points: 100,
-  platform_fee_recipient: "{{wallet_address}}",
 
   // Optional Royalty fee information
   fee_recipient: "{{wallet_address}}",


### PR DESCRIPTION
Due to a recent changes in the contract, `platform_fee_recipient` & `platform_fee_basis_points` are no more an optional parameter while deploying a pre-built contract/